### PR TITLE
格式修复

### DIFF
--- a/Question_01_10/README.md
+++ b/Question_01_10/README.md
@@ -1,11 +1,11 @@
 # 问题一至问题十
 ## 问题一：通道交换
 
-读取图像，然后将$\text{RGB}$通道替换成$\text{BGR}$通道。
+读取图像，然后将 $\text{RGB}$ 通道替换成 $\text{BGR}$ 通道。
 
 下面的代码用于提取图像的红色通道。
 
-注意，`cv2.imread()` 的系数是按$\text{BGR}$顺序排列的！
+注意，`cv2.imread()` 的系数是按 $\text{BGR}$ 顺序排列的！
 
 其中的变量`red`表示的是仅有原图像红通道的`imori.jpg`。
 
@@ -15,7 +15,7 @@ img = cv2.imread("imori.jpg")
 red = img[:, :, 2].copy()
 ```
 
-| 输入（imori.jpg) | 输出(answers_image/answer_1.jpg) |
+| 输入(imori.jpg) | 输出(answers_image/answer_1.jpg) |
 | :--------------: | :------------------------------: |
 |  ![](imori.jpg)  | ![](answers_image/answer_1.jpg)  |
 
@@ -29,11 +29,12 @@ red = img[:, :, 2].copy()
 将图像灰度化吧！
 
 灰度是一种图像亮度的表示方法，通过下式计算：
+
 $$
-Y = 0.2126\  R + 0.7152\  G + 0.0722\  B
+Y = 0.2126\cdot  R + 0.7152\cdot  G + 0.0722\cdot  B
 $$
 
-| 输入（imori.jpg) | 输出(answers_image/answer_2.jpg) |
+| 输入(imori.jpg) | 输出(answers_image/answer_2.jpg) |
 | :--------------: | :------------------------------: |
 |  ![](imori.jpg)  | ![](answers_image/answer_2.jpg)  |
 
@@ -42,13 +43,15 @@ $$
 > * Python >> [answers_py/answer_2.py](answers_py/answer_2.py)
 >
 > * C++ >> [answers_cpp/answer_2.cpp](answers_cpp/answer_2.cpp)
+
 ## 问题三：二值化（Thresholding）
 
 把图像进行二值化吧。
 
 二值化是将图像使用黑和白两种颜色表示的方法。
 
-我们将灰度的阈值设置为$128$来进行二值化，即：
+我们将灰度的阈值设置为 $128$ 来进行二值化，即：
+
 $$
 y=
 \begin{cases}
@@ -57,7 +60,7 @@ y=
 \end{cases}
 $$
 
-| 输入（imori.jpg) | 输出(answers_image/answer_3.jpg) |
+| 输入(imori.jpg) | 输出(answers_image/answer_3.jpg) |
 | :--------------: | :------------------------------: |
 |  ![](imori.jpg)  | ![](answers_image/answer_3.jpg)  |
 
@@ -75,18 +78,18 @@ $$
 从**类内方差**和**类间方差**的比值计算得来：
 
 
-- 小于阈值$t$的类记作$0$，大于阈值$t$的类记作$1$；
-- $w_0$和$w_1$是被阈值$t$分开的两个类中的像素数占总像素数的比率（满足$w_0+w_1=1$）；
-- ${S_0}^2$， ${S_1}^2$是这两个类中像素值的方差；
-- $M_0$，$M_1$是这两个类的像素值的平均值；
+- 小于阈值 $t$ 的类记作 $0$ ，大于阈值 $t$ 的类记作 $1$ ；
+- $w_0$ 和 $w_1$ 是被阈值 $t$ 分开的两个类中的像素数占总像素数的比率（满足 $w_0+w_1=1$ ）；
+- ${S_0}^2$ ， ${S_1}^2$ 是这两个类中像素值的方差；
+- $M_0$ ， $M_1$ 是这两个类的像素值的平均值；
 
 即：
 
-* 类内方差：${S_w}^2=w_0\ {S_0}^2+w_1\  {S_1}^2$
-* 类间方差：${S_b}^2 = w_0 \  (M_0 - M_t)^2 + w_1\ (M_1 - M_t)^2 = w_0\  w_1\  (M_0 - M_1) ^2$
-* 图像所有像素的方差：${S_t}^2 = {S_w}^2 + {S_b}^2 = \text{常数}$
+* 类内方差： ${S_w}^2=w_0\ {S_0}^2+w_1\  {S_1}^2$
+* 类间方差： ${S_b}^2 = w_0 \  (M_0 - M_t)^2 + w_1\ (M_1 - M_t)^2 = w_0\  w_1\  (M_0 - M_1) ^2$
+* 图像所有像素的方差： ${S_t}^2 = {S_w}^2 + {S_b}^2 = \text{常数}$
 
-根据以上的式子，我们用以下的式子计算分离度$X$：[^1]
+根据以上的式子，我们用以下的式子计算分离度 $X$ ：[^1]
 
 [^1]: 这里原repo配图里的公式好像打错了。
 
@@ -95,59 +98,67 @@ X = \frac{{S_b}^2}{{S_w}^2} = \frac{{S_b}^2}{{S_t}^2 - {S_b}^2}
 $$
 
 也就是说： 
+
 $$
 \arg\max\limits_{t}\ X=\arg\max\limits_{t}\ {S_b}^2
 $$
-换言之，如果使${S_b}^2={w_0}\ {w_1}\ (M_0 - M_1)^2$最大，就可以得到最好的二值化阈值$t$。
 
-| 输入（imori.jpg) | 输出 ($\text{th} = 127$​) (answers_image/answer_4.jpg) |
+换言之，如果使 ${S_b}^2={w_0}\ {w_1}\ (M_0 - M_1)^2$ 最大，就可以得到最好的二值化阈值 $t$ 。
+
+| 输入(imori.jpg) | 输出 ( $\text{th} = 127$ ​) (answers_image/answer_4.jpg) |
 | :--------------: | :----------------------------------------------------: |
 |  ![](imori.jpg)  |            ![](answers_image/answer_4.jpg)             |
 
 > 答案
-> Python >> [answers/answer_4.py](answers/answer_4.py)
-> C++ >> [answers_cpp/answer_4.py](answers_cpp/answer_4.py)
+>
+> * Python >> [answers/answer_4.py](answers/answer_4.py)
+> * C++ >> [answers_cpp/answer_4.py](answers_cpp/answer_4.py)
 
-## 问题五：$\text{HSV}$变换
+## 问题五： $\text{HSV}$ 变换
 
-将使用$\text{HSV}$表示色彩的图像的色相反转吧！
+将使用 $\text{HSV}$ 表示色彩的图像的色相反转吧！
 
-$\text{HSV}$即使用**色相（Hue）、饱和度（Saturation）、明度（Value）**来表示色彩的一种方式。
+$\text{HSV}$ 即使用<b>色相（Hue）、饱和度（Saturation）、明度（Value）</b>来表示色彩的一种方式。
 
-- 色相：将颜色使用$0^{\circ}$到$360^{\circ}$表示，就是平常所说的颜色名称，如红色、蓝色。色相与数值按下表对应：
+- 色相：将颜色使用 $0^{\circ}$ 到 $360^{\circ}$ 表示，就是平常所说的颜色名称，如红色、蓝色。色相与数值按下表对应：
 
   | 红          | 黄           | 绿            | 青色          | 蓝色          | 品红          | 红            |
   | ----------- | ------------ | ------------- | ------------- | ------------- | ------------- | ------------- |
   | $0^{\circ}$ | $60^{\circ}$ | $120^{\circ}$ | $180^{\circ}$ | $240^{\circ}$ | $300^{\circ}$ | $360^{\circ}$ |
 
-- 饱和度：是指色彩的纯度，饱和度越低则颜色越黯淡（$0\leq S < 1$）；
-- 明度：即颜色的明暗程度。数值越高越接近白色，数值越低越接近黑色（$0\leq V < 1$）；
+- 饱和度：是指色彩的纯度，饱和度越低则颜色越黯淡（ $0\leq S < 1$ ）；
+- 明度：即颜色的明暗程度。数值越高越接近白色，数值越低越接近黑色（ $0\leq V < 1$ ）；
 
-从$\text{RGB}$色彩表示转换到$\text{HSV}$色彩表示通过以下方式计算：
+从 $\text{RGB}$ 色彩表示转换到 $\text{HSV}$ 色彩表示通过以下方式计算：
 
-$\text{RGB}$的取值范围为$[0, 1]$，令：
-$$
-\text{Max}=\max(R,G,B)\\
-\text{Min}=\min(R,G,B)
-$$
+$\text{RGB}$ 的取值范围为 $[0, 1]$ ，令：
+
+$$\text{Max}=\max(R,G,B)\\
+\text{Min}=\min(R,G,B)$$
+
 色相：
-$$
-H=\begin{cases}
+
+$$H=\begin{cases}
 0&(\text{if}\ \text{Min}=\text{Max})\\
 60\  \frac{G-R}{\text{Max}-\text{Min}}+60&(\text{if}\ \text{Min}=B)\\
 60\  \frac{B-G}{\text{Max}-\text{Min}}+180&(\text{if}\ \text{Min}=R)\\
 60\  \frac{R-B}{\text{Max}-\text{Min}}+300&(\text{if}\ \text{Min}=G)
-\end{cases}
-$$
+\end{cases}$$
+
 饱和度：
+
 $$
 S=\text{Max}-\text{Min}
 $$
+
 明度：
+
 $$
 V=\text{Max}
 $$
-从$\text{HSV}$色彩表示转换到$\text{RGB}$色彩表示通过以下方式计算：
+
+从 $\text{HSV}$ 色彩表示转换到 $\text{RGB}$ 色彩表示通过以下方式计算：
+
 $$
 C = S\\
 H' = \frac{H}{60}\\
@@ -162,9 +173,10 @@ X = C\  (1 - |H' \mod 2 - 1|)\\
 (C, 0, X)&  (\text{if}\quad 5 \leq H' < 6)
 \end{cases}
 $$
-请将色相反转（色相值加$180$），然后再用$\text{RGB}$色彩空间表示图片。
 
-| 输入（imori.jpg) | 输出(answers_image/answer_5.jpg) |
+请将色相反转（色相值加 $180$），然后再用 $\text{RGB}$ 色彩空间表示图片。
+
+| 输入(imori.jpg) | 输出(answers_image/answer_5.jpg) |
 | :--------------: | :------------------------------: |
 |  ![](imori.jpg)  | ![](answers_image/answer_5.jpg)  |
 
@@ -177,7 +189,8 @@ $$
 
 [^2]: 这里没有找到"減色処理"准确的中文翻译，所以直译了。
 
-我们将图像的值由$256^3$压缩至$4^3$，即将$\text{RGB}$的值只取$\{32, 96, 160, 224\}$。这被称作色彩量化。色彩的值按照下面的方式定义：
+我们将图像的值由 $256^3$ 压缩至 $4^3$ ，即将 $\text{RGB}$ 的值只取 $\{32, 96, 160, 224\}$ 。这被称作色彩量化。色彩的值按照下面的方式定义：
+
 $$
 \text{val}=
 \begin{cases}
@@ -188,7 +201,7 @@ $$
 \end{cases}
 $$
 
-| 输入（imori.jpg) | 输出(answers_image/answer_6.jpg) |
+| 输入(imori.jpg) | 输出(answers_image/answer_6.jpg) |
 | :--------------: | :------------------------------: |
 |  ![](imori.jpg)  | ![](answers_image/answer_6.jpg)  |
 
@@ -201,15 +214,17 @@ $$
 
 将图片按照固定大小网格分割，网格内的像素值取网格内所有像素的平均值。
 
-我们将这种把图片使用均等大小网格分割，并求网格内代表值的操作称为**池化（Pooling）**。
+我们将这种把图片使用均等大小网格分割，并求网格内代表值的操作称为<b>池化（Pooling）</b>。
 
-池化操作是**卷积神经网络（Convolutional Neural Network）**中重要的图像处理方式。平均池化按照下式定义：
+池化操作是<b>卷积神经网络（Convolutional Neural Network）</b>中重要的图像处理方式。平均池化按照下式定义：
+
 $$
 v=\frac{1}{|R|}\  \sum\limits_{i=1}^R\ v_i
 $$
-请把大小为$128\times128$的`imori.jpg`使用$8\times8$的网格做平均池化。
 
-| 输入（imori.jpg) | 输出(answers_image/answer_7.jpg) |
+请把大小为 $128\times 128$ 的`imori.jpg`使用 $8\times 8$ 的网格做平均池化。
+
+| 输入(imori.jpg) | 输出(answers_image/answer_7.jpg) |
 | :--------------: | :------------------------------: |
 |  ![](imori.jpg)  | ![](answers_image/answer_7.jpg)  |
 
@@ -222,7 +237,7 @@ $$
 
 网格内的值不取平均值，而是取网格内的最大值进行池化操作。
 
-| 输入（imori.jpg) | 输出(answers_image/answer_8.jpg) |
+| 输入(imori.jpg) | 输出(answers_image/answer_8.jpg) |
 | :--------------: | :------------------------------: |
 |  ![](imori.jpg)  | ![](answers_image/answer_8.jpg)  |
 
@@ -232,20 +247,22 @@ $$
 
 ## 问题九：高斯滤波（Gaussian Filter）
 
-使用高斯滤波器（$3\times3$大小，标准差$\sigma=1.3$）来对`imori_noise.jpg`进行降噪处理吧！
+使用高斯滤波器（ $3\times 3$ 大小，标准差 $\sigma=1.3$ ）来对`imori_noise.jpg`进行降噪处理吧！
 
 高斯滤波器是一种可以使图像**平滑**的滤波器，用于去除**噪声**。可用于去除噪声的滤波器还有中值滤波器（参见问题十），平滑滤波器（参见问题十一）、LoG滤波器（参见问题十九）。
 
-高斯滤波器将中心像素周围的像素按照高斯分布加权平均进行平滑化。这样的（二维）权值通常被称为**卷积核（kernel）**或者**滤波器（filter）**。
+高斯滤波器将中心像素周围的像素按照高斯分布加权平均进行平滑化。这样的（二维）权值通常被称为<b>卷积核（kernel）</b>或者<b>滤波器（filter）</b>。
 
-但是，由于图像的长宽可能不是滤波器大小的整数倍，因此我们需要在图像的边缘补$0$。这种方法称作**Zero Padding**。并且权值$g$（卷积核）要进行[归一化操作](https://blog.csdn.net/lz0499/article/details/54015150)（$\sum\ g = 1$）。
+但是，由于图像的长宽可能不是滤波器大小的整数倍，因此我们需要在图像的边缘补 $0$ 。这种方法称作**Zero Padding**。并且权值 $g$（卷积核）要进行[归一化操作](https://blog.csdn.net/lz0499/article/details/54015150)（ $\sum g = 1$ ）。
 
 按下面的高斯分布公式计算权值：
+
 $$
 g(x,y,\sigma)=\frac{1}{2\  \pi\ \sigma^2}\  e^{-\frac{x^2+y^2}{2\  \sigma^2}}
 $$
 
-标准差$\sigma=1.3$的$8-$近邻高斯滤波器如下：
+标准差 $\sigma=1.3$ 的 $8-$ 近邻高斯滤波器如下：
+
 $$
 K=\frac{1}{16}\  \left[
  \begin{matrix}
@@ -256,7 +273,7 @@ K=\frac{1}{16}\  \left[
   \right]
 $$
 
-| 输入（imori_noise.jpg) | 输出(answers_image/answer_9.jpg) |
+| 输入(imori_noise.jpg) | 输出(answers_image/answer_9.jpg) |
 | :--------------------: | :------------------------------: |
 |  ![](imori_noise.jpg)  | ![](answers_image/answer_9.jpg)  |
 
@@ -267,11 +284,11 @@ $$
 
 ## 问题十：中值滤波（Median Filter）
 
-使用中值滤波器（$3\times3$大小）来对`imori_noise.jpg`进行降噪处理吧！
+使用中值滤波器（ $3\times 3$ 大小）来对`imori_noise.jpg`进行降噪处理吧！
 
-中值滤波器是一种可以使图像平滑的滤波器。这种滤波器用滤波器范围内（在这里是$3\times3$）像素点的中值进行滤波，请在这里也采用Zero Padding。
+中值滤波器是一种可以使图像平滑的滤波器。这种滤波器用滤波器范围内（在这里是 $3\times 3$ ）像素点的中值进行滤波，请在这里也采用Zero Padding。
 
-| 输入（imori_noise.jpg) | 输出(answers_image/answer_10.jpg) |
+| 输入(imori_noise.jpg) | 输出(answers_image/answer_10.jpg) |
 | :--------------------: | :-------------------------------: |
 |  ![](imori_noise.jpg)  | ![](answers_image/answer_10.jpg)  |
 


### PR DESCRIPTION
Q1-10，不用插件正常显式<b>加粗</b>， $\text{公式：} x=y$ ，修复全角半角符号混杂